### PR TITLE
Fix header text clipping on mobile

### DIFF
--- a/coronary-intervention/index.html
+++ b/coronary-intervention/index.html
@@ -62,7 +62,8 @@ body::before{content:'';position:fixed;inset:0;background:radial-gradient(ellips
 .header{text-align:center;margin-bottom:20px;padding:44px 12px 28px;border-bottom:none;position:relative}
 .header::after{content:'';position:absolute;bottom:0;left:50%;transform:translateX(-50%);width:80%;height:1px;background:linear-gradient(90deg,transparent,rgba(96,165,250,.55),rgba(139,92,246,.45),rgba(45,212,191,.4),transparent)}
 .header-eyebrow{display:block;font-family:'JetBrains Mono',monospace;font-size:9px;font-weight:700;letter-spacing:.38em;text-transform:uppercase;color:var(--blue);opacity:.65;margin-bottom:14px}
-.header h1{font-size:clamp(28px,9vw,62px);font-weight:800;letter-spacing:.04em;text-transform:uppercase;background:linear-gradient(135deg,#60a5fa 0%,#a78bfa 42%,#2dd4bf 100%);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;margin-bottom:12px;line-height:1.05;filter:drop-shadow(0 0 36px rgba(96,165,250,.18))}
+.header h1{font-size:clamp(28px,9vw,62px);font-weight:800;letter-spacing:.04em;text-transform:uppercase;background:linear-gradient(135deg,#60a5fa 0%,#a78bfa 42%,#2dd4bf 100%);-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;margin-bottom:12px;line-height:1.05;filter:drop-shadow(0 0 36px rgba(96,165,250,.18));overflow-wrap:break-word;word-break:break-word;padding:0 8px}
+@media(max-width:480px){.header h1{font-size:clamp(22px,11.5vw,42px);letter-spacing:.01em}}
 .header p{font-size:10px;color:var(--text-faint);font-family:'JetBrains Mono',monospace;letter-spacing:.05em;opacity:.75;margin-bottom:0}
 </style>
 </head>


### PR DESCRIPTION
Fixes "REFERENC" clipping on narrow mobile screens. Adds a responsive font-size reduction and tightens letter-spacing below 480px so the full word fits within the viewport.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lgdp97Ca3j6FfUHvtqfb2a)_