### PR TITLE
Remove duplicate disclaimer from top of page

### DIFF
--- a/coronary-intervention/index.html
+++ b/coronary-intervention/index.html
@@ -73,10 +73,6 @@ body::before{content:'';position:fixed;inset:0;background:radial-gradient(ellips
 #back-home{position:fixed;top:16px;left:16px;z-index:900;font-family:'JetBrains Mono',monospace;font-size:10px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:rgba(96,165,250,.55);text-decoration:none;border:1px solid rgba(96,165,250,.18);padding:6px 12px;border-radius:20px;background:rgba(10,14,26,.6);backdrop-filter:blur(8px);transition:color .2s,border-color .2s,background .2s}
 #back-home:hover{color:#60a5fa;border-color:rgba(96,165,250,.5);background:rgba(96,165,250,.08)}
 </style>
-<div id="disclaimer">&#9888;&nbsp; Educational resource for trainees and fellows only. Not for clinical use. Always reference official publications and discuss with your supervisor.</div>
-<style>
-#disclaimer{background:rgba(245,158,11,.07);border-bottom:1px solid rgba(245,158,11,.2);color:rgba(245,158,11,.75);font-family:'JetBrains Mono',monospace;font-size:9.5px;letter-spacing:.04em;text-align:center;padding:8px 16px;line-height:1.5}
-</style>
 <div class="header">
 <span class="header-eyebrow">Interventional Cardiology</span>
 <h1>Key Values Reference</h1>


### PR DESCRIPTION
Removes the leftover old disclaimer block (orange box) that was still sitting at the top of the page. Only the gold text version inside the header remains.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lgdp97Ca3j6FfUHvtqfb2a)_