### PR TITLE
Add bifurcation techniques, SB loss scenario, rotablation steps

### DIFF
--- a/coronary-intervention/index.html
+++ b/coronary-intervention/index.html
@@ -86,7 +86,7 @@ body::before{content:'';position:fixed;inset:0;background:radial-gradient(ellips
 <nav class="nav">
 <a href="#sizing">Sizing</a><a href="#catheters">Catheters</a><a href="#wires">Guide Wires</a><a href="#physiology">Physiology</a>
 <a href="#imaging">IVUS/OCT</a><a href="#anticoag">Anticoagulation</a><a href="#antiplatelets">Antiplatelets</a>
-<a href="#stents">Stents</a><a href="#balloons">Balloons</a><a href="#atherectomy">Atherectomy</a>
+<a href="#stents">Stents</a><a href="#bifurcation">Bifurcation</a><a href="#balloons">Balloons</a><a href="#atherectomy">Atherectomy</a>
 <a href="#haemo">Haemodynamics</a><a href="#classifications">Classifications</a><a href="#scores">Risk Scores</a>
 <a href="#mcs">MCS</a><a href="#largebore">Large Bore</a><a href="#escalation">Escalation</a><a href="#complications">Complications</a><a href="#radiation">Radiation</a><a href="#contrast">Contrast</a><a href="#trials">Trials</a>
 </nav>
@@ -603,6 +603,146 @@ body::before{content:'';position:fixed;inset:0;background:radial-gradient(ellips
 <tr><td>Delivery shaft (RX)</td><td>140-145 cm</td></tr>
 </table></div></div>
 </div>
+<div id="bifurcation" class="section-title">Bifurcation Techniques</div>
+<div class="grid">
+<div class="card full"><div class="card-header"><div class="dot" style="background:var(--blue)"></div><h2>Overview &amp; Decision Algorithm</h2></div>
+<div class="sub-label">medina classification reminder</div>
+<table>
+<tr><td>True bifurcation (two-stent consider)</td><td class="v-coral">Medina (1,1,1) / (1,0,1) / (0,1,1) — SB ostial disease present</td></tr>
+<tr><td>Non-true bifurcation (provisional default)</td><td class="v-green">Medina (1,1,0) / (1,0,0) / (0,1,0) — SB ostium usually unaffected</td></tr>
+</table>
+<div class="sub-label">provisional first (one-stent default)</div>
+<table>
+<tr><td>Default approach</td><td class="v-green">Provisional stenting — one-stent unless compelling indication for two-stent</td></tr>
+<tr><td>Key evidence</td><td>NORDIC I/II: no MACE benefit to routine two-stent for non-LM bifurcations. Provisional established as default.</td></tr>
+<tr><td>OCTOBER 2023</td><td class="v-green">OCT-guided bifurcation PCI: MACE RR 0.63 vs angio — image all bifurcations</td></tr>
+</table>
+<div class="sub-label">two-stent indications</div>
+<table>
+<tr><td>SB size + disease</td><td class="v-amber">SB diameter &ge;2.5 mm with &gt;5 mm ostial disease (not just plaque shift)</td></tr>
+<tr><td>Large territory</td><td>First diagonal, large OM, PDA — SB loss would cause significant ischaemia</td></tr>
+<tr><td>Anatomy</td><td>Bifurcation angle &lt;70°, likely SB occlusion risk, long SB ostial lesion</td></tr>
+<tr><td>LM bifurcation</td><td class="v-coral">LM + LAD/LCx — two-stent strongly preferred; DK Crush gold standard (DKCRUSH-V)</td></tr>
+</table>
+<div class="sub-label">technique selection</div>
+<table>
+<tr><td>T Stenting</td><td>Angle exactly 90°; rare ideal anatomy; largely historical — TAP preferred</td></tr>
+<tr><td>TAP</td><td>Angle &lt;70–90°; modification of T; most common rescue/elective technique; 1–2 mm protrusion into MV</td></tr>
+<tr><td>Culotte</td><td>Similar MV/SB calibres; wide angle; acceptable for non-LM large SB (DKCRUSH-III: DK superior to Culotte)</td></tr>
+<tr><td>DK Crush</td><td class="v-green">LM bifurcation (DKCRUSH-V); complex true bifurcation; large SB &ge;2.5 mm — highest evidence base</td></tr>
+</table>
+</div>
+
+<div class="card full"><div class="card-header"><div class="dot" style="background:var(--teal)"></div><h2>Provisional Stenting — Standard One-Stent Approach</h2></div>
+<div class="sub-label">steps</div>
+<table>
+<tr><td>1 — Wire both vessels</td><td>Workhorse wire in MV and SB; confirm wire positions fluoroscopically in two views</td></tr>
+<tr><td>2 — Predilate</td><td>MV &plusmn; SB as needed; NC balloon for calcified lesions; avoid routine SB predilation (risk of dissection)</td></tr>
+<tr><td>3 — Stent MV</td><td>Deploy MV stent covering bifurcation; SB wire jailed inside stent struts</td></tr>
+<tr><td>4 — POT</td><td class="v-blue">Large NC balloon in proximal MV sized to proximal MV diameter; appose proximal stent + open distal strut cells for rewiring</td></tr>
+<tr><td>5 — Assess SB</td><td>TIMI flow, residual ostial stenosis, ECG change, haemodynamic status</td></tr>
+<tr><td>6a — SB acceptable</td><td class="v-green">Remove SB wire. Final angiogram. Done — no further intervention needed.</td></tr>
+<tr><td>6b — SB compromised</td><td class="v-amber">Rewire SB through <strong>distal stent cell</strong> (Sion Blue or Fielder FC; not proximal cell — causes carina shift)</td></tr>
+<tr><td>7 — KBI</td><td>NC in MV (sized to distal MV) + NC in SB (sized to SB); inflate SB first then both simultaneously to same pressure</td></tr>
+<tr><td>8 — Final rePOT</td><td class="v-coral">NC in proximal MV only — restores proximal circularity; never inflate MV alone after KBI without this step</td></tr>
+</table>
+<div class="sub-label">never do</div>
+<table>
+<tr><td>Never</td><td class="v-coral">Rewire SB through proximal cell / inflate MV-only post-KBI without rePOT / skip POT / assume SB acceptable without imaging if vessel &ge;2.5 mm</td></tr>
+</table>
+</div>
+
+<div class="card full"><div class="card-header"><div class="dot" style="background:var(--blue)"></div><h2>T Stenting</h2></div>
+<div class="sub-label">best for: bifurcation angle exactly 90° — rare; largely historical; TAP usually preferred</div>
+<table>
+<tr><td>1 — Wire both vessels</td><td>Workhorse wire in MV and SB; predilate as needed</td></tr>
+<tr><td>2 — Position SB stent</td><td class="v-coral">Flush at SB ostium — <strong>zero protrusion into MV</strong>; any protrusion risks MV lumen obstruction</td></tr>
+<tr><td>3 — Deploy SB stent</td><td>Remove SB wire and delivery catheter</td></tr>
+<tr><td>4 — Stent MV</td><td>MV stent deployed covering bifurcation; jails SB stent ostium</td></tr>
+<tr><td>5 — Rewire SB</td><td>Through MV stent struts (Sion Blue or Fielder FC)</td></tr>
+<tr><td>6 — KBI + rePOT</td><td>Simultaneous NC MV + NC SB kissing balloon; final rePOT in proximal MV</td></tr>
+</table>
+<div class="sub-label">limitation</div>
+<table>
+<tr><td>Key limitation</td><td class="v-amber">Flush positioning only achievable at exactly 90°; ostial gap common at other angles — TAP preferred in most real-world cases</td></tr>
+</table>
+</div>
+
+<div class="card full"><div class="card-header"><div class="dot" style="background:var(--purple)"></div><h2>TAP — T and Protrusion</h2></div>
+<div class="sub-label">best for: angles &lt;70–90°; most common two-stent technique; modification of T ensuring full ostial coverage</div>
+<table>
+<tr><td>1 — Wire both vessels</td><td>Workhorse wire in MV and SB</td></tr>
+<tr><td>2 — Stent MV first</td><td>Deploy MV stent; SB wire jailed</td></tr>
+<tr><td>3 — POT</td><td class="v-blue">Large NC in proximal MV — opens distal cells for SB rewiring</td></tr>
+<tr><td>4 — Rewire SB</td><td>Through distal MV stent cell (Sion Blue or Fielder FC)</td></tr>
+<tr><td>5 — Predilate SB</td><td>NC balloon through MV stent struts at SB ostium</td></tr>
+<tr><td>6 — Position SB stent</td><td class="v-amber">Advance SB stent to protrude <strong>1–2 mm into MV</strong> — ensures full ostial SB coverage regardless of angle</td></tr>
+<tr><td>7 — Position MV balloon</td><td>Advance NC balloon alongside protruding SB stent in MV (not inflated yet)</td></tr>
+<tr><td>8 — Deploy SB stent</td><td>Deploy SB stent; remove SB delivery catheter</td></tr>
+<tr><td>9 — KBI + rePOT</td><td>Simultaneous NC MV + NC SB kissing balloon; final rePOT proximal MV</td></tr>
+</table>
+<div class="sub-label">TAP vs T stenting</div>
+<table>
+<tr><td>Key advantage over T</td><td class="v-green">1–2 mm protrusion guarantees complete SB ostial coverage at any bifurcation angle — preferred over T stenting in practice</td></tr>
+</table>
+</div>
+
+<div class="card full"><div class="card-header"><div class="dot" style="background:var(--teal)"></div><h2>Culotte</h2></div>
+<div class="sub-label">best for: similar-calibre vessels (MV &asymp; SB &ge;2.5 mm); wide bifurcation angle; non-LM large SB</div>
+<table>
+<tr><td>1 — Wire both; predilate</td><td>Workhorse wire in MV and SB; NC balloon predilation of both recommended</td></tr>
+<tr><td>2 — Stent SB first</td><td class="v-amber">SB stent protruding <strong>2–3 mm into MV</strong>; covers bifurcation from SB side</td></tr>
+<tr><td>3 — Deploy SB stent</td><td>Remove SB delivery system</td></tr>
+<tr><td>4 — POT of SB stent</td><td class="v-blue">Large NC in proximal MV portion of SB stent — appose + open cells for MV rewiring</td></tr>
+<tr><td>5 — Rewire MV through SB stent</td><td>Rewire MV <strong>through SB stent struts</strong>; remove original MV wire after confirmed</td></tr>
+<tr><td>6 — Open MV cells</td><td>NC balloon through SB stent struts into MV — expand struts for stent passage</td></tr>
+<tr><td>7 — Stent MV through SB stent</td><td>Advance MV stent through SB stent into distal MV; deploy covering full bifurcation</td></tr>
+<tr><td>8 — Rewire SB through MV stent</td><td>Rewire SB through new MV stent struts (distal cell)</td></tr>
+<tr><td>9 — KBI + final rePOT</td><td>Simultaneous NC MV + NC SB kissing; final rePOT proximal MV</td></tr>
+</table>
+<div class="sub-label">note</div>
+<table>
+<tr><td>Double stent layer at carina</td><td class="v-amber">Both stents cover the bifurcation — more metal at carina; excellent ostial SB coverage; avoid in dissimilar vessel sizes or acute angles</td></tr>
+</table>
+</div>
+
+<div class="card full"><div class="card-header"><div class="dot" style="background:var(--green)"></div><h2>DK Crush — Double Kissing Crush</h2></div>
+<div class="sub-label">best for: LM bifurcation (DKCRUSH-V gold standard); complex true bifurcation; large SB &ge;2.5 mm</div>
+<table>
+<tr><td>1 — Wire both; predilate SB</td><td>Workhorse wires in MV and SB; NC balloon predilation of SB strongly recommended</td></tr>
+<tr><td>2 — Position SB stent</td><td class="v-amber">SB stent protruding <strong>3–4 mm into MV</strong>; position MV balloon alongside (not inflated)</td></tr>
+<tr><td>3 — Deploy SB stent</td><td>Remove SB delivery catheter; keep MV wire and balloon in position</td></tr>
+<tr><td>4 — CRUSH</td><td class="v-coral">Inflate MV balloon — crushes protruding SB stent struts against MV wall; remove MV balloon</td></tr>
+<tr><td>5 — Rewire SB (1st time)</td><td>Rewire SB through crushed stent struts (Sion Blue / Fielder FC); advance NC SB balloon through crushed struts</td></tr>
+<tr><td>6 — 1st KBI (DK step 1)</td><td class="v-blue"><strong>Simultaneous NC MV + NC SB</strong> — fully expands crushed SB ostium <strong>before</strong> MV stent deployed; this is the key DK step</td></tr>
+<tr><td>7 — Deploy MV stent</td><td>Remove SB balloon (keep SB wire); deploy MV stent over crushed + kissed SB stent ostium</td></tr>
+<tr><td>8 — Rewire SB (2nd time)</td><td>Rewire SB through new MV stent struts (through distal cell; not proximal)</td></tr>
+<tr><td>9 — 2nd KBI + final rePOT (DK step 2)</td><td class="v-green">Simultaneous NC MV + NC SB kissing; final rePOT large NC proximal MV</td></tr>
+</table>
+<div class="sub-label">why double kissing vs standard crush</div>
+<table>
+<tr><td>DK vs standard crush</td><td class="v-green">Intermediate KBI (step 6) expands crushed struts fully before MV stent — prevents strut under-coverage at SB ostium; ↓ TLR and ↓ thrombosis</td></tr>
+<tr><td>DKCRUSH-V (NEJM 2019)</td><td class="v-green">DK Crush vs provisional for LM bifurcation: 30-day MACE 5.0% vs 10.7% (p=0.02). Gold standard for LM.</td></tr>
+<tr><td>DKCRUSH-III (2013)</td><td class="v-green">DK Crush vs Culotte for non-LM bifurcations: TLF 6.2% vs 10.3%. DK superior to Culotte.</td></tr>
+</table>
+<div class="sub-label">never do</div>
+<table>
+<tr><td>Never</td><td class="v-coral">Skip the intermediate KBI / rewire through proximal cell / attempt DK without IVUS guidance / leave without final rePOT</td></tr>
+</table>
+</div>
+
+<div class="card full"><div class="card-header"><div class="dot" style="background:var(--amber)"></div><h2>POT / KBI / rePOT — Quick Reference</h2></div>
+<table>
+<tr><td>POT</td><td class="v-blue">NC balloon sized to <strong>proximal MV diameter</strong>; deployed at bifurcation; appose proximal stent + open distal cells for SB rewiring</td></tr>
+<tr><td>KBI</td><td>Simultaneous NC in MV (distal MV diameter) + NC in SB (SB diameter); inflate SB first, then both simultaneously to same pressure</td></tr>
+<tr><td>rePOT</td><td class="v-coral">NC in <strong>proximal MV only</strong> after KBI — restores proximal MV circularity distorted by kissing inflation</td></tr>
+<tr><td>Balloon type for POT/rePOT</td><td class="v-coral">NC only — never SC for POT; prevents proximal over-expansion of non-diseased vessel</td></tr>
+<tr><td>Standard sequence</td><td class="v-green">POT → rewire SB → KBI → rePOT applies to ALL two-stent techniques</td></tr>
+<tr><td>Critical rule</td><td class="v-coral">Never inflate MV-only balloon after KBI without rePOT — causes carina shift and acute SB compromise</td></tr>
+</table>
+</div>
+</div>
+
 <div id="balloons" class="section-title">Balloons</div>
 <div class="grid">
 <div class="card"><div class="card-header"><div class="dot" style="background:var(--teal)"></div><h2>Balloon Pressures &amp; Sizing</h2></div>
@@ -666,6 +806,34 @@ body::before{content:'';position:fixed;inset:0;background:radial-gradient(ellips
 <tr><td>Key advantage</td><td>Treats nodular, deep, circumferential Ca; tortuous vessels; workhorse wire</td></tr>
 <tr><td>Key trial</td><td>DISRUPT CAD III - 92.4% procedural success, 7.6% MACE at 30 days</td></tr>
 </table></div></div>
+
+<div class="card full"><div class="card-header"><div class="dot" style="background:var(--amber)"></div><h2>Rotablation — Procedural Steps</h2></div>
+<div class="sub-label">preparation</div>
+<table>
+<tr><td>1 — Guide selection</td><td>7 Fr (AL or EBU for LCA; AL1 for RCA); 8 Fr for &ge;2.0 mm burr; ensure coaxial engagement without damping</td></tr>
+<tr><td>2 — Rotaflow cocktail</td><td>Heparin + verapamil 2.5–5 mg + GTN 100 mcg in saline; infuse continuously via dedicated manifold sideport throughout ablation</td></tr>
+<tr><td>3 — Wire exchange</td><td>Cross lesion with workhorse wire first; exchange to Rotawire Floppy (tortuous = Extra Support) via microcatheter; confirm distal position</td></tr>
+<tr><td>4 — ACT check</td><td class="v-coral">ACT &ge;300 s before ablation; re-check if procedure prolonged</td></tr>
+<tr><td>5 — Temporary pacing</td><td class="v-amber">RCA / dominant vessel lesions and bradycardia-prone patients — prophylactic TPW before starting ablation</td></tr>
+</table>
+<div class="sub-label">ablation technique</div>
+<table>
+<tr><td>6 — Confirm RPM</td><td>140,000–180,000 RPM; verify stable on console before advancing burr to lesion</td></tr>
+<tr><td>7 — Pecking motion</td><td class="v-blue">Advance burr 1–2 mm at a time; never force; allow burr to decelerate fully between passes; each run &le;15–20 seconds</td></tr>
+<tr><td>8 — Monitor RPM continuously</td><td class="v-coral">Drop &gt;5,000 RPM = advancing too aggressively; pull back immediately; let decelerate; re-advance more slowly</td></tr>
+<tr><td>9 — Burr escalation</td><td>Upsize burr if inadequate calcium modification; max burr:artery ratio 0.6; typically 2–3 passes per burr size</td></tr>
+</table>
+<div class="sub-label">after ablation</div>
+<table>
+<tr><td>10 — Wire exchange back</td><td>Exchange Rotawire to workhorse wire via microcatheter before balloon or stent</td></tr>
+<tr><td>11 — Post-rota balloon</td><td>SC balloon first at low pressure (lesion compliance now changed); then NC balloon pre-dilation; confirm adequate preparation before stenting</td></tr>
+<tr><td>12 — IVUS/OCT mandatory</td><td class="v-green">Confirm calcium modification and adequate lumen; guide stent sizing and post-dilation endpoints</td></tr>
+</table>
+<div class="sub-label">never do</div>
+<table>
+<tr><td>Never</td><td class="v-coral">Advance burr without rotaflow running / Ignore &gt;5,000 RPM deceleration / Burr:artery ratio &gt;0.6 / Use non-dedicated (non-Rotawire) wire / Skip post-rota imaging</td></tr>
+</table>
+</div>
 </div>
 <div id="haemo" class="section-title">Haemodynamics &amp; LV Gram</div>
 <div class="grid">
@@ -1126,6 +1294,31 @@ body::before{content:'';position:fixed;inset:0;background:radial-gradient(ellips
 <tr><td>J-CTO score</td><td class="v-teal">0 = easy → 4+ = very difficult; predicts procedural complexity and time</td></tr>
 <tr><td>CTO PCI success rates</td><td class="v-green">85–95% at experienced centres — requires dedicated training and proctorship</td></tr>
 </table></div>
+
+<div class="card full"><div class="card-header"><div class="dot" style="background:var(--teal)"></div><h2>Scenario 7 — Side Branch Loss After Main Vessel Stent</h2></div>
+<div class="sub-label">recognition and immediate response</div>
+<table>
+<tr><td>Recognition</td><td>TIMI &le;1 in SB after MV stent; ECG change; haemodynamic instability if large territory at risk</td></tr>
+<tr><td>Act if SB &ge;2.5 mm</td><td class="v-coral">Significant territory (diagonal, OM, PDA) — intervene; &lt;2.0 mm minor territory — usually conservative</td></tr>
+<tr><td>First step</td><td>Confirm MV wire still in good position; keep any jailed SB wire in place; do not remove wires</td></tr>
+</table>
+<div class="sub-label">rewiring and balloon escalation</div>
+<table>
+<tr><td>1 — Rewire SB</td><td class="v-blue">Through <strong>distal MV stent cell</strong> (not proximal cell — causes carina shift); Sion Blue or Fielder FC</td></tr>
+<tr><td>2 — Balloon SB</td><td>1.5–2.0 mm SC balloon at low pressure through stent struts to restore flow; upsize to NC matching SB if residual significant</td></tr>
+<tr><td>3 — Assess result</td><td>TIMI 3 + residual &lt;75% + small territory = conservative acceptable; IVUS/OCT if available</td></tr>
+</table>
+<div class="sub-label">stenting the SB if needed — TAP is the rescue technique</div>
+<table>
+<tr><td>TAP preferred</td><td>Advance SB stent 1–2 mm into MV; position MV NC alongside; deploy; KBI + rePOT</td></tr>
+<tr><td>Not Culotte/DK at rescue</td><td class="v-amber">Culotte and DK require planned two-stent setup — TAP is the appropriate unplanned rescue two-stent option</td></tr>
+<tr><td>IVUS/OCT post-intervention</td><td>Confirm stent apposition, no edge dissection, MV result not compromised</td></tr>
+</table>
+<div class="sub-label">never do</div>
+<table>
+<tr><td>Never</td><td class="v-coral">Assume SB loss acceptable without assessment if &ge;2.5 mm / Use hydrophilic wire as first rewire wire / Rewire through proximal stent cell / Deploy SB stent without confirming MV wire position</td></tr>
+</table>
+</div>
 </div>
 
 <div id="complications" class="section-title">Complication Management</div>


### PR DESCRIPTION
## New content

**Bifurcation Techniques section** (7 cards, id="bifurcation", nav link added):
- Decision algorithm — Medina reminder, one vs two-stent indications, technique selection guide
- Provisional stenting — full step-by-step with POT/KBI/rePOT sequence
- T Stenting — steps + limitations
- TAP (T and Protrusion) — steps, comparison to T
- Culotte — steps, vessel calibre guidance
- DK Crush — 9-step procedure with both kissing balloon steps, DKCRUSH-V/III evidence
- POT/KBI/rePOT quick reference table

**Escalation Scenario 7** — Side Branch Loss After Main Vessel Stent (recognition, rewiring, balloon escalation, TAP rescue, never-do rules)

**Rotablation Procedural Steps** — full-width card added to atherectomy section (preparation, ablation technique, post-rota protocol, never-do rules)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lgdp97Ca3j6FfUHvtqfb2a)_